### PR TITLE
Admin now shows on nav when an admin user is logged in

### DIFF
--- a/public_html/admin/index.php
+++ b/public_html/admin/index.php
@@ -1,7 +1,11 @@
 <?php
 require_once( $_SERVER['DOCUMENT_ROOT'] . '/bootstrap.php');
+$page_title = "Admin";
+$javascript = <<<HERE
+HERE;
+
 // Authentication  and Authorization System
-ob_start();
+ob_start('template');
 session_start();
 
 if (!isset($_SESSION["id"])) {
@@ -23,48 +27,8 @@ if (!$_SESSION["admin"]) {
 }
 
 ?>
-<!doctype html>
-    <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no, shrink-to-fit=no">
-        <title>Skeleton HTML</title>
-
-        <link href="https://fonts.googleapis.com/css2?family=Playfair+Display&family=Raleway:wght@300;400;600&display=swap" rel="stylesheet">
-        <!--<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">-->
-        <link href="/css/races.css" rel="stylesheet">
-
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-        <style>
-            nav#main-navigation li {
-                display: inline-block;
-                width: 18%;
-            }
-            nav#main-navigation ul {
-                margin:0;
-                padding:0;
-            }
-        </style>
-    </head>
-<body>
-<!--The main navigation menu to be displayed on most pages. Not all links work yet.-->
-<nav id="main-navigation">
-    <h1>Main Navigation</h1>
-    <ul>
-        <li><a href="http://localhost/races">Races</a></li>
-        <li><a href="http://localhost/HOF/">HOF</a></li>
-        <li><a href="http://localhost/faq/">FAQ</a></li>
-        <li><a href="http://localhost/user/">Me</a></li>
-        <?php
-        if ($_SESSION['admin']) {
-            echo <<< ADMIN
-<li><a href= "http://localhost/admin/">Admin</a></li>
-ADMIN;
-        }
-        ?>
-        <li><a href="http://localhost/logout">Log out</a></li>
-    </ul>
-</nav>
+{header}
+{main_nav}
     <main role="main">
         <section>
             <h1>The Stables</h1>
@@ -78,8 +42,5 @@ ADMIN;
      
     </main>
 
-<footer>
-    <p>Created by students of the College of Informatics at Northern Kentucky University</p>
-</footer>
-</body>
-</html>
+{footer}
+<?php ob_end_flush(); ?>

--- a/public_html/faq/index.php
+++ b/public_html/faq/index.php
@@ -5,6 +5,7 @@ $javascript = <<<HERE
 HERE;
 // turn on output buffering 
 ob_start('template');
+session_start();
 ?>
 {header}
 {main_nav}

--- a/public_html/hof/index.php
+++ b/public_html/hof/index.php
@@ -5,6 +5,7 @@ $javascript = <<<HERE
 HERE;
 // turn on output buffering 
 ob_start('template');
+session_start();
 ?>
 {header}
 {main_nav}

--- a/public_html/template/main_nav.php
+++ b/public_html/template/main_nav.php
@@ -21,7 +21,7 @@ $nav = <<< HTML
  
 HTML;
 
-if(true){
+if($_SESSION["admin"]){
 $nav .= <<< HTML
                 <li class="nav-item" id="admin">
                     <a class="nav-link" href="/admin/">Admin</a>


### PR DESCRIPTION
Fixed nav bar so that the admin tab is shown when an admin is logged in and not when a non-admin user is logged in.

Fixed bug where admin tab was not showing up on the HOF & FAQ tabs even when an admin was logged in.